### PR TITLE
Fully initialize Scroll pHAT HD when creating I2CDisplay

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -60,7 +60,50 @@ impl I2CDisplay {
             device: d,
             frame: 0,
         };
-        display.register(CONFIG_BANK, MODE_REGISTER, PICTURE_MODE);
+
+        // Display initialization
+        display.reset();
+
+        display.device.smbus_write_byte_data(BANK_ADDRESS, CONFIG_BANK);
+        // Switch to Picture Mode
+        display.device.smbus_write_byte_data(MODE_REGISTER, PICTURE_MODE);
+        // Disable audio sync
+        display.device.smbus_write_byte_data(AUDIOSYNC_REGISTER, 0);
+
+        // Initialize frame 1
+        display.device.smbus_write_byte_data(BANK_ADDRESS, 1);
+        // Turn off blinking for all LEDs
+        for i in 0..17 {
+            display.device.smbus_write_byte_data(BLINK_OFFSET + i, 0);
+        }
+        // Set the PWM duty cycle for all LEDs to 0%
+        for i in 0..17 {
+            for j in 0..7 {
+                display.device.smbus_write_byte_data(COLOR_OFFSET + (i * 8) + j, 0);
+            }
+        }
+        // Turn all LEDs "on"
+        for i in 0..17 {
+            display.device.smbus_write_byte_data(ENABLE_OFFSET + i, 127);
+        }
+
+        // Initialize frame 0
+        display.device.smbus_write_byte_data(BANK_ADDRESS, 0);
+        // Turn off blinking for all LEDs
+        for i in 0..17 {
+            display.device.smbus_write_byte_data(BLINK_OFFSET + i, 0);
+        }
+        // Set the PWM duty cycle for all LEDs to 0%
+        for i in 0..17 {
+            for j in 0..7 {
+                display.device.smbus_write_byte_data(COLOR_OFFSET + (i * 8) + j, 0);
+            }
+        }
+        // Turn all LEDs "on"
+        for i in 0..17 {
+            display.device.smbus_write_byte_data(ENABLE_OFFSET + i, 127);
+        }
+
         display
     }
 
@@ -75,7 +118,7 @@ impl I2CDisplay {
         value: u8,
     ) -> Result<(), i2cdev::linux::LinuxI2CError> {
         self.bank(bank);
-        self.device.smbus_write_block_data(register, &[value])
+        self.device.smbus_write_byte_data(register, value)
     }
 
     fn frame(&mut self, frame: u8) -> Result<(), i2cdev::linux::LinuxI2CError> {


### PR DESCRIPTION
~~This doesn't fully work yet. I wanted to get this up as a PR to start talking about how to get it working.~~

I noticed that I wouldn't get any display output on the Scroll pHAT HD if the display/RasPI had been power cycled. At least not until after I ran one of the Pimoroni example apps, at which point I would get output from an app using `scroll_phat_hd`.

Looking at the Python library the Pimoroni example apps are using, it does [a fair bit more to initialize the display](https://github.com/pimoroni/scroll-phat-hd/blob/c9d3284919664845757e4f0a7d692f3dfab9c722/library/scrollphathd/is31fl3731.py#L108-L126). ~~I tried pulling in what the Python library is doing, but I get a few dead pixels on the display (one whole column, except for one pixel toward the center) when using this version of the initialization. It's definitely something in the way I'm doing the initialization here, since I can run one of the Pimoroni example apps, and the previously unresponsive pixels work fine. The dead column is 100% reproducible switching back and forth between the Python library, and the Rust one.~~