### PR TITLE
Enable double-buffered rendering to the display

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -139,9 +139,7 @@ impl I2CDisplay {
 #[cfg(target_os = "linux")]
 impl Display for I2CDisplay {
     fn show(&mut self, buffer: &[Column]) {
-        // TODO(tzn): Double buffering.
-        // let new_frame = (self.frame + 1) % 2;
-        let new_frame = 1;
+        let new_frame = (self.frame + 1) % 2;
         self.bank(new_frame);
         for y in 0..DISPLAY_HEIGHT {
             for x in 0..DISPLAY_WIDTH {

--- a/src/display.rs
+++ b/src/display.rs
@@ -60,7 +60,50 @@ impl I2CDisplay {
             device: d,
             frame: 0,
         };
-        display.register(CONFIG_BANK, MODE_REGISTER, PICTURE_MODE);
+
+        // Display initialization
+        display.reset();
+
+        display.device.smbus_write_byte_data(BANK_ADDRESS, CONFIG_BANK);
+        // Switch to Picture Mode
+        display.device.smbus_write_byte_data(MODE_REGISTER, PICTURE_MODE);
+        // Disable audio sync
+        display.device.smbus_write_byte_data(AUDIOSYNC_REGISTER, 0);
+
+        // Initialize frame 1
+        display.device.smbus_write_byte_data(BANK_ADDRESS, 1);
+        // Turn off blinking for all LEDs
+        for i in 0..17 {
+            display.device.smbus_write_byte_data(BLINK_OFFSET + i, 0);
+        }
+        // Set the PWM duty cycle for all LEDs to 0%
+        for i in 0..17 {
+            for j in 0..7 {
+                display.device.smbus_write_byte_data(COLOR_OFFSET + (i * 8) + j, 0);
+            }
+        }
+        // Turn all LEDs "on"
+        for i in 0..17 {
+            display.device.smbus_write_byte_data(ENABLE_OFFSET + i, 127);
+        }
+
+        // Initialize frame 0
+        display.device.smbus_write_byte_data(BANK_ADDRESS, 0);
+        // Turn off blinking for all LEDs
+        for i in 0..17 {
+            display.device.smbus_write_byte_data(BLINK_OFFSET + i, 0);
+        }
+        // Set the PWM duty cycle for all LEDs to 0%
+        for i in 0..17 {
+            for j in 0..7 {
+                display.device.smbus_write_byte_data(COLOR_OFFSET + (i * 8) + j, 0);
+            }
+        }
+        // Turn all LEDs "on"
+        for i in 0..17 {
+            display.device.smbus_write_byte_data(ENABLE_OFFSET + i, 127);
+        }
+
         display
     }
 
@@ -75,7 +118,7 @@ impl I2CDisplay {
         value: u8,
     ) -> Result<(), i2cdev::linux::LinuxI2CError> {
         self.bank(bank);
-        self.device.smbus_write_block_data(register, &[value])
+        self.device.smbus_write_byte_data(register, value)
     }
 
     fn frame(&mut self, frame: u8) -> Result<(), i2cdev::linux::LinuxI2CError> {


### PR DESCRIPTION
Turns out that the reason double-buffering was not working previously was due to the usage of smbus_write_block_data and that it corrupts the data it sends. Now that we're no longer using smbus_write_block_data, the way that double-buffered rendering was being attempted Just Works(TM).

This PR depends on the changes in #2 (and should show a _significantly_ smaller diff once that PR is merged).