### PR TITLE
Write I2C data in up to 32-byte chunks

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -83,10 +83,12 @@ impl I2CDisplay {
     }
 
     fn write_data(&mut self, base_address: u8, data: &[u8]) -> Result<(), LinuxI2CError> {
-        for i in 0..data.len() {
-            self.device
-                .smbus_write_byte_data(base_address + (i as u8), data[i])?;
+        let mut offset = 0;
+        for chunk in data.chunks(32) {
+            self.device.smbus_process_block(base_address + offset, chunk)?;
+            offset += 32;
         }
+
         Ok(())
     }
 


### PR DESCRIPTION
Unfortunately, `smbus_write_block_data` writes data according to SMBus 2.0 spec (Section 5.5.7 Block read/write), which means that it includes the number of bytes to be written after the command code.

`i2c_smbus_write_i2c_block_data` writes the data immediately following the command code (leaving off the length byte), but has the misleading name of [`smbus_process_block`](https://github.com/rust-embedded/rust-i2cdev/blob/c1acac88569a79e1de41e0265d604fef6171e542/src/linux.rs#L216), incorrectly states that it also reads data, and incorrectly states that it has a maximum of 31 bytes in the
`i2cdev` Rust library.